### PR TITLE
feat: Add Terraform `1.6.6`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          VERSIONS=$(jq keys_unsorted versions.json)
+          VERSIONS=$(jq -c keys_unsorted versions.json)
           echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
         id: generate
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,12 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: |
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Check Nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@v5
+      - name: Output versions
+        run: |
           VERSIONS=$(jq -c keys_unsorted versions.json)
           echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
         id: generate
@@ -24,15 +28,11 @@ jobs:
     needs: [setup]
     strategy:
       matrix:
-        version: ['1.6.6', '1.6.5', '1.5.0']
-        # version: ${{ fromJSON(needs.setup.outputs.versions) }}
+        version: ${{ fromJSON(needs.setup.outputs.versions) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      # - name: Check Nix flake inputs
-      #   uses: DeterminateSystems/flake-checker-action@v5
       - name: Install Nix
-        # uses: DeterminateSystems/nix-installer-action@v9
         uses: cachix/install-nix-action@v24
       - name: Setup Cachix
         uses: cachix/cachix-action@v13

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          VERSIONS=$(jq keys_unsorted versions.json)
+          echo ::set-output name=versions::${VERSIONS}
+        id: generate
+    outputs:
+      versions: ${{ steps.generate.outputs.versions }}
+
   build:
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -29,6 +41,7 @@ jobs:
           NIXPKGS_ALLOW_UNFREE: 1
 
   templates:
+    if: false
     strategy:
       matrix:
         template: [default, devenv]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           # skipPush: ${{ github.ref_name != 'main' }}
       - name: Build package
-        run: nix build --impure .#"${{ matrix.version }}"
+        run: nix build --impure '.#"${{ matrix.version }}"'
         env:
           NIXPKGS_ALLOW_UNFREE: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,15 @@ jobs:
     outputs:
       versions: ${{ steps.generate.outputs.versions }}
 
+  test:
+    runs-on: ubuntu-latest
+    needs: [matrix]
+    strategy:
+      matrix:
+        version: ${{ matrix.outputs.versions }}
+    steps:
+      - run: echo ${{ matrix.version }}
+
   build:
     if: false
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,29 +7,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # setup:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #     - name: Check Nix flake inputs
-  #       uses: DeterminateSystems/flake-checker-action@v5
-  #     - name: Output versions
-  #       run: |
-  #         VERSIONS=$(jq -c keys_unsorted versions.json)
-  #         echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
-  #       id: generate
-  #   outputs:
-  #     versions: ${{ steps.generate.outputs.versions }}
-
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # needs: [setup]
-    # strategy:
-    #   matrix:
-    #     version: ${{ fromJSON(needs.setup.outputs.versions) }}
-    #   fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,9 +21,8 @@ jobs:
           name: nixpkgs-terraform
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           skipPush: false
-      - name: Build package
-        run: |
-          cachix watch-exec nixpkgs-terraform -- nix flake check --impure --max-jobs $(nproc) --cores 1 --keep-going
+      - name: Build packages
+        run: cachix watch-exec nixpkgs-terraform -- nix flake check --impure --max-jobs auto --cores 0 --keep-going
         env:
           NIXPKGS_ALLOW_UNFREE: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,26 +40,24 @@ jobs:
         with:
           name: nixpkgs-terraform
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          # skipPush: ${{ github.ref_name != 'main' }}
+          skipPush: ${{ github.ref_name != 'main' }}
       - name: Build package
         run: nix build --impure '.#"${{ matrix.version }}"'
         env:
           NIXPKGS_ALLOW_UNFREE: 1
 
-  templates:
-    if: false
-    strategy:
-      matrix:
-        template: [default, devenv]
-      fail-fast: true
+  template:
     runs-on: ubuntu-latest
     timeout-minutes: 4
     needs: [build]
+    strategy:
+      matrix:
+        template: [default, devenv]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v9
+        uses: cachix/install-nix-action@v24
       - name: Replace inputs on templates
         run: sed -i 's/github:stackbuilders\/nixpkgs-terraform/github:stackbuilders\/nixpkgs-terraform\/${{ github.sha }}/g' templates/*/flake.nix
       - name: Create a temporary directory
@@ -70,6 +68,6 @@ jobs:
         working-directory: ${{ steps.mktemp.outputs.tmpdir }}
       - name: Run smoke test
         run: nix develop --accept-flake-config --impure -c terraform --version
+        working-directory: ${{ steps.mktemp.outputs.tmpdir }}
         env:
           NIXPKGS_ALLOW_UNFREE: 1
-        working-directory: ${{ steps.mktemp.outputs.tmpdir }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,11 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    # timeout-minutes: 2
+    timeout-minutes: 5
     needs: [setup]
     strategy:
       matrix:
-        version: ['1.6.6', '1.5.0']
+        version: ['1.6.6', '1.6.5', '1.5.0']
         # version: ${{ fromJSON(needs.setup.outputs.versions) }}
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
 
   template:
     runs-on: ubuntu-latest
-    timeout-minutes: 4
+    timeout-minutes: 2
     needs: [build]
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
     strategy:
       matrix:
         version: ${{ fromJSON(needs.setup.outputs.versions) }}
+      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    # timeout-minutes: 2
     needs: [setup]
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
+  foo:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,10 +20,10 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [matrix]
+    needs: [foo]
     strategy:
       matrix:
-        version: ${{ matrix.outputs.versions }}
+        version: ${{ fromJSON(foo.outputs.versions) }}
     steps:
       - run: echo ${{ matrix.version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  foo:
+  setup:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,10 +20,10 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [foo]
+    needs: [setup]
     strategy:
       matrix:
-        version: ${{ fromJSON(foo.outputs.versions) }}
+        version: ${{ fromJSON(needs.setup.outputs.versions) }}
     steps:
       - run: echo ${{ matrix.version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,29 +7,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Check Nix flake inputs
-        uses: DeterminateSystems/flake-checker-action@v5
-      - name: Output versions
-        run: |
-          VERSIONS=$(jq -c keys_unsorted versions.json)
-          echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
-        id: generate
-    outputs:
-      versions: ${{ steps.generate.outputs.versions }}
+  # setup:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #     - name: Check Nix flake inputs
+  #       uses: DeterminateSystems/flake-checker-action@v5
+  #     - name: Output versions
+  #       run: |
+  #         VERSIONS=$(jq -c keys_unsorted versions.json)
+  #         echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
+  #       id: generate
+  #   outputs:
+  #     versions: ${{ steps.generate.outputs.versions }}
 
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [setup]
-    strategy:
-      matrix:
-        version: ${{ fromJSON(needs.setup.outputs.versions) }}
-      fail-fast: false
+    # needs: [setup]
+    # strategy:
+    #   matrix:
+    #     version: ${{ fromJSON(needs.setup.outputs.versions) }}
+    #   fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -42,7 +42,14 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           skipPush: ${{ github.ref_name != 'main' }}
       - name: Build package
-        run: nix build --impure '.#"${{ matrix.version }}"'
+        run: |
+          # jq keys_unsorted[] versions.json | while read -r VERSION
+          for VERSION in "1.6.6" "1.5.6"  
+          do
+            echo "::group::Building Terraform version $VERSION"
+            nix build --impure ".#\"$VERSION\""
+            echo "::endgroup::"
+          done
         env:
           NIXPKGS_ALLOW_UNFREE: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,34 +18,30 @@ jobs:
     outputs:
       versions: ${{ steps.generate.outputs.versions }}
 
-  test:
+  build:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     needs: [setup]
     strategy:
       matrix:
-        version: ${{ fromJSON(needs.setup.outputs.versions) }}
-    steps:
-      - run: echo ${{ matrix.version }}
-
-  build:
-    if: false
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+        version: ['1.6.6', '1.5.0']
+        # version: ${{ fromJSON(needs.setup.outputs.versions) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Check Nix flake inputs
-        uses: DeterminateSystems/flake-checker-action@v5
+      # - name: Check Nix flake inputs
+      #   uses: DeterminateSystems/flake-checker-action@v5
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v9
+        # uses: DeterminateSystems/nix-installer-action@v9
+        uses: cachix/install-nix-action@v24
       - name: Setup Cachix
         uses: cachix/cachix-action@v13
         with:
           name: nixpkgs-terraform
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          skipPush: ${{ github.ref_name != 'main' }}
-      - name: Build all packages
-        run: nix flake check --impure
+          # skipPush: ${{ github.ref_name != 'main' }}
+      - name: Build package
+        run: nix build --impure .#"${{ matrix.version }}"
         env:
           NIXPKGS_ALLOW_UNFREE: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     # needs: [setup]
     # strategy:
     #   matrix:
@@ -43,13 +43,7 @@ jobs:
           skipPush: false
       - name: Build package
         run: |
-          # jq keys_unsorted[] versions.json | while read -r VERSION
-          for VERSION in "1.6.6" "1.5.6"  
-          do
-            echo "::group::Building Terraform version $VERSION"
-            cachix watch-exec nixpkgs-terraform -- nix build --impure ".#\"$VERSION\""
-            echo "::endgroup::"
-          done
+          cachix watch-exec nixpkgs-terraform -- nix flake check --impure --max-jobs $(nproc) --cores 1 --keep-going
         env:
           NIXPKGS_ALLOW_UNFREE: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           VERSIONS=$(jq keys_unsorted versions.json)
-          echo ::set-output name=versions::${VERSIONS}
+          echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
         id: generate
     outputs:
       versions: ${{ steps.generate.outputs.versions }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,14 +40,14 @@ jobs:
         with:
           name: nixpkgs-terraform
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          skipPush: ${{ github.ref_name != 'main' }}
+          skipPush: false
       - name: Build package
         run: |
           # jq keys_unsorted[] versions.json | while read -r VERSION
           for VERSION in "1.6.6" "1.5.6"  
           do
             echo "::group::Building Terraform version $VERSION"
-            nix build --impure ".#\"$VERSION\""
+            cachix watch-exec nixpkgs-terraform -- nix build --impure ".#\"$VERSION\""
             echo "::endgroup::"
           done
         env:

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1698553279,
-        "narHash": "sha256-T/9P8yBSLcqo/v+FTOBK+0rjzjPMctVymZydbvR/Fak=",
+        "lastModified": 1703105089,
+        "narHash": "sha256-1F7hDLj58OQCADRtG2DRKpmJ8QVza0M0NK/kfLWLs3k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "90e85bc7c1a6fc0760a94ace129d3a1c61c3d035",
+        "rev": "2b9c57d33e3d5be6262e124fc66e3a8bc650b93d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1703105089,
-        "narHash": "sha256-1F7hDLj58OQCADRtG2DRKpmJ8QVza0M0NK/kfLWLs3k=",
+        "lastModified": 1704008649,
+        "narHash": "sha256-rGPSWjXTXTurQN9beuHdyJhB8O761w1Zc5BqSSmHvoM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2b9c57d33e3d5be6262e124fc66e3a8bc650b93d",
+        "rev": "d44d59d2b5bd694cd9d996fd8c51d03e3e9ba7f7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
               )
               pkgs-unstable.nix-prefetch
               pkgs.nodejs
+              pkgs.rubyPackages.dotenv
             ];
           };
           # https://github.com/NixOS/nix/issues/7165

--- a/update-versions.py
+++ b/update-versions.py
@@ -70,7 +70,7 @@ def calculate_vendor_hash(versions, version, calculated_hash, vendor_hash):
         return nix_prefetch(
             [
                 "--file",
-                vendor_hash.resolve(),
+                str(vendor_hash.resolve()),
                 "--argstr",
                 "version",
                 version,

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,8 @@
 {
+  "1.6.6": {
+    "hash": "sha256-fYFmHypzSbSgut9Wij6Sz8xR97DVOwPLQap6pan7IRA=",
+    "vendorHash": "sha256-fQsxTX1v8HsMDIkofeCVfNitJAaTWHwppC7DniXlvT4="
+  },
   "1.6.5": {
     "hash": "sha256-TJKs7pWoLFIeov/ERgPqZxPtbjSAHrHI2wrSEXUAS1A=",
     "vendorHash": "sha256-QHfCGlgOv4v3MzUs4JxIHytcyymUYmnk4Z0smgak1Mg="


### PR DESCRIPTION
@oscar-izval to build `1.6.6`, upgrade `nixpkgs-unstable` was required; however, doing so forces rebuild of most packages; thus, I decided to change the way we build packages to allow incremental builds, as rebuilding everything in a single shot is more prone to error and leaves less room to cache individual packages, as if any package fails, the ones that were successfully built will not be pushed to Cachix.