### PR TITLE
ci: Fix FlakeHub release pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
         uses: DeterminateSystems/flakehub-push@v3
         with:
           tag: ${{ inputs.tag || github.ref_name }}
+          visibility: public
 
   flakestry:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A missing field is currently causing an issue in the FlakeHub publishing pipeline:

<img width="878" alt="image" src="https://github.com/stackbuilders/nixpkgs-terraform/assets/2049686/a321f393-1690-4cd3-b090-5cf6a32a79a0">
