### PR TITLE
Fix for semantic prerelease

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,5 +1,8 @@
-branches: [{ name: main, prerelease: true }]
+---
+# Note: master branch is not used for releases, but we need it to be there to
+# overcome https://github.com/semantic-release/semantic-release/issues/2503
+branches: [master, {name: 'main', prerelease: true}]
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
-  - ["@semantic-release/github", { successComment: false }]
+  - ["@semantic-release/github", {successComment: false}]


### PR DESCRIPTION
Current behaviour of `semantic-release` prevents the usage of the main branch for prereleases, this is explained [here](https://github.com/semantic-release/semantic-release/issues/2503). To circumvent that, we can use another branch as a placeholder so that semantic-release sees a valid release branch not meant to be a prerelease.

This is a bit hacky and there are some valid points in the link above, but given that the prerelease workflow was meant to be replaced with direct releases at some point, I wouldn't be against "hacking" our way through this for the time being while the project matures a bit more. Any thoughts on this @sestrella?

Note: we'd need to push a `master` branch for this to work.