### PR TITLE
PoC: Add support for older Terraform versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           skipPush: false
       - name: Build packages
-        run: cachix watch-exec nixpkgs-terraform -- nix flake check --impure --max-jobs auto --cores 0 --keep-going
+        run: nix flake check --impure --max-jobs auto --cores 0 --keep-going
         env:
           NIXPKGS_ALLOW_UNFREE: 1
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This flake provides a set of Terraform versions in the form of:
 nixpkgs-terraform.packages.${system}.${version}
 ```
 
-Supported Terraform versions ([endoflife.date/terraform](https://endoflife.date/terraform))
-are kept up to date via a weekly scheduled [CI workflow](.github/workflows/update.yml).
+Terraform versions `>= 1.5.0` are kept up to date via a weekly scheduled [CI
+workflow](.github/workflows/update.yml).
 
 ## Install
 

--- a/flake.lock
+++ b/flake.lock
@@ -22,16 +22,32 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706373441,
-        "narHash": "sha256-S1hbgNbVYhuY2L05OANWqmRzj4cElcbLuIkXTb69xkk=",
+        "lastModified": 1699291058,
+        "narHash": "sha256-5ggduoaAMPHUy4riL+OrlAZE14Kh7JWX4oLEs22ZqfU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "56911ef3403a9318b7621ce745f5452fb9ef6867",
+        "rev": "41de143fda10e33be0f47eab2bfe08a50f234267",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1704008649,
+        "narHash": "sha256-rGPSWjXTXTurQN9beuHdyJhB8O761w1Zc5BqSSmHvoM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d44d59d2b5bd694cd9d996fd8c51d03e3e9ba7f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -40,6 +56,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "systems": "systems"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,28 +4,30 @@
   inputs = {
     flake-utils.inputs.systems.follows = "systems";
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
     systems.url = "github:nix-systems/default";
   };
 
-  outputs = { self, flake-utils, nixpkgs, ... }:
+  outputs = { self, flake-utils, nixpkgs-unstable, nixpkgs, ... }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
           versions = builtins.fromJSON (builtins.readFile ./versions.json);
         in
         {
           devShells.default = pkgs.mkShell {
             buildInputs = [
-              pkgs.black
-              (pkgs.python3.withPackages
+              pkgs-unstable.black
+              (pkgs-unstable.python3.withPackages
                 (ps: [
                   ps.pygithub
                   ps.semver
                 ])
               )
-              pkgs.nix-prefetch
+              pkgs-unstable.nix-prefetch
               pkgs.nodejs
               pkgs.rubyPackages.dotenv
             ];
@@ -41,10 +43,20 @@
       lib.buildTerraform = { system, version, hash, vendorHash }:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
         in
+        # https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+        if builtins.compareVersions version "1.6.0" >= 0
+        then
         # https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/pkgs/applications/networking/cluster/terraform/default.nix
-        pkgs.mkTerraform
-          {
+          pkgs-unstable.mkTerraform
+            {
+              inherit version hash vendorHash;
+              patches = [ "${nixpkgs-unstable}/pkgs/applications/networking/cluster/terraform/provider-path-0_15.patch" ];
+            }
+        else
+        # https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/applications/networking/cluster/terraform/default.nix
+          pkgs.mkTerraform {
             inherit version hash vendorHash;
             patches = [ "${nixpkgs}/pkgs/applications/networking/cluster/terraform/provider-path-0_15.patch" ];
           };

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -14,7 +14,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        terraform = nixpkgs-terraform.packages.${system}."1.7.1";
+        terraform = nixpkgs-terraform.packages.${system}."1.6.3";
       in
       {
         devShells.default = pkgs.mkShell {

--- a/templates/devenv/flake.nix
+++ b/templates/devenv/flake.nix
@@ -15,7 +15,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        terraform = nixpkgs-terraform.packages.${system}."1.7.1";
+        terraform = nixpkgs-terraform.packages.${system}."1.6.3";
       in
       {
         devShells.default = devenv.lib.mkShell {

--- a/update-versions.py
+++ b/update-versions.py
@@ -124,4 +124,3 @@ versions = collections.OrderedDict(
 )
 with open("versions.json", "w") as f:
     json.dump(versions, f, indent=2)
-    f.write("\n")

--- a/versions.json
+++ b/versions.json
@@ -70,5 +70,25 @@
   "1.5.0": {
     "hash": "sha256-QLCmA4u0br9EyQ244VcpLW5GkZm+bhq2/vvxSbYolCY=",
     "vendorHash": "sha256-tfCfJj39VP+P4qhJTpEIAi4XB+6VYtVKkV/bTrtnFA0="
+  },
+  "1.4.7": {
+    "hash": "sha256-p+6sNCYdqygbSL4plsWxtcs8GqFq5pyaTxFttBWWqaE=",
+    "vendorHash": "sha256-OW/aS6aBoHABxfdjDxMJEdHwLuHHtPR2YVW4l0sHPjE="
+  },
+  "1.3.10": {
+    "hash": "sha256-XOuhPZEb4CkynIRYIpg4zdlngym+1urndVYkoZGbeQ8=",
+    "vendorHash": "sha256-CE6jNBvM0980+R0e5brK5lMrkad+91qTt9mp2h3NZyY="
+  },
+  "1.2.9": {
+    "hash": "sha256-Q5AJiFnbHXhIJP06SCJNvuMKGwEJUOsmueCI7QCeQlk=",
+    "vendorHash": "sha256-VKJ+aWZYD6N8HDJwUEtgWxoBMGOa27K9ze2RUJvuipc="
+  },
+  "1.1.9": {
+    "hash": "sha256-6dyP3Y5cK+/qLoC2QPZW3QNgqOeVXegC06Pa7pSv1iE=",
+    "vendorHash": "sha256-YI/KeoOIxgCAS3Q6SXaW8my0PyFD+pyksshQEAknsz4="
+  },
+  "1.0.11": {
+    "hash": "sha256-Z2qFetJZgylRbf75oKEr8blPhQcABxcE1nObUD/RBUw=",
+    "vendorHash": "sha256-4oSL7QT6KjZlt3NKkjNWcrZA8yCkx6aI2kYsdyh8L68="
   }
 }

--- a/versions.json
+++ b/versions.json
@@ -38,5 +38,37 @@
   "1.6.0": {
     "hash": "sha256-R1phgtGn9hyNqa0wR1zY9uThTJSIj7TuK5ekXx48QP0=",
     "vendorHash": "sha256-V7S+IzHfBhIHo0xCvHJ75gOmvVbJd2k8XBdvLG1dcsc="
+  },
+  "1.5.7": {
+    "hash": "sha256-pIhwJfa71/gW7lw/KRFBO4Q5Z5YMcTt3r9kD25k8cqM=",
+    "vendorHash": "sha256-lQgWNMBf+ioNxzAV7tnTQSIS840XdI9fg9duuwoK+U4="
+  },
+  "1.5.6": {
+    "hash": "sha256-vbV8Tmas7n1o8Q+DG9RrcfdAMa4bJsVg2SsTFH1TJ5M=",
+    "vendorHash": "sha256-lQgWNMBf+ioNxzAV7tnTQSIS840XdI9fg9duuwoK+U4="
+  },
+  "1.5.5": {
+    "hash": "sha256-SBS3a/CIUdyIUJvc+rANIs+oXCQgfZut8b0517QKq64=",
+    "vendorHash": "sha256-lQgWNMBf+ioNxzAV7tnTQSIS840XdI9fg9duuwoK+U4="
+  },
+  "1.5.4": {
+    "hash": "sha256-MvN4gSJcPORD0wj6ixc3gUXPISGvAKSJPA6bS/SmDOY=",
+    "vendorHash": "sha256-lQgWNMBf+ioNxzAV7tnTQSIS840XdI9fg9duuwoK+U4="
+  },
+  "1.5.3": {
+    "hash": "sha256-4TnTYzjy8v5+mcV/JIiMPLCTPSanfmbTGzwlMovwlOo=",
+    "vendorHash": "sha256-lQgWNMBf+ioNxzAV7tnTQSIS840XdI9fg9duuwoK+U4="
+  },
+  "1.5.2": {
+    "hash": "sha256-Ri2nWLjPPBINXyPIQSbnd1L+t7QLgXiTOgqX8Dk/rXg=",
+    "vendorHash": "sha256-tfCfJj39VP+P4qhJTpEIAi4XB+6VYtVKkV/bTrtnFA0="
+  },
+  "1.5.1": {
+    "hash": "sha256-dqnJGIoUJP37Z77TR2RBxP94Hx3AZbx90m8z1FoYdw0=",
+    "vendorHash": "sha256-tfCfJj39VP+P4qhJTpEIAi4XB+6VYtVKkV/bTrtnFA0="
+  },
+  "1.5.0": {
+    "hash": "sha256-QLCmA4u0br9EyQ244VcpLW5GkZm+bhq2/vvxSbYolCY=",
+    "vendorHash": "sha256-tfCfJj39VP+P4qhJTpEIAi4XB+6VYtVKkV/bTrtnFA0="
   }
 }


### PR DESCRIPTION
- Revert "feat: Drop support for Terraform 1.5 versions (#26)"
- Add initial support for 1.0 up to 1.4 versions
- Avoid pushing artifacts to Cachix
