### PR TITLE
ci: Wrap build command with Cachix only if token is present

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,13 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           skipPush: false
       - name: Build packages
-        run: cachix watch-exec nixpkgs-terraform -- nix flake check --impure --max-jobs auto --cores 0 --keep-going
+        run: |
+          build_command="nix flake check --impure --max-jobs auto --cores 0 --keep-going"
+          if [ -z "${CACHIX_AUTH_TOKEN}" ]; then
+            $build_command
+          else
+            cachix watch-exec nixpkgs-terraform -- $build_command
+          fi
         env:
           NIXPKGS_ALLOW_UNFREE: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,10 @@ jobs:
         run: |
           build_command="nix flake check --impure --max-jobs auto --cores 0 --keep-going"
           if [ -z "${CACHIX_AUTH_TOKEN}" ]; then
+            echo "Cachix token is not present"
             $build_command
           else
+            echo "Cachix token is present"
             cachix watch-exec nixpkgs-terraform -- $build_command
           fi
         env:


### PR DESCRIPTION
This patch should allow builds from a fork to work, avoiding issues like the one listed below:

https://github.com/stackbuilders/nixpkgs-terraform/actions/runs/8066471878/job/22034572008