### PR TITLE
fix: Drop duplicated `all` from cycle packages name

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           versions = import ./lib/packages.nix { inherit pkgs pkgs-unstable; custom-lib = self.lib; };
           linkPackagesByCycle = versionsPerCycle: builtins.mapAttrs
             (cycle: cycleVersions: pkgs.symlinkJoin {
-              name = "terraform-all-${cycle}";
+              name = "terraform-${cycle}";
               paths = builtins.map (version: versions.${version}) cycleVersions;
             })
             versionsPerCycle;


### PR DESCRIPTION
The word `all` appears twice in the names of the cycle packages:

```
this derivation will be built:
  /nix/store/vqn18gq4sd0v24v48rxv16nhyw4dv6rp-terraform-all-all-1.6.drv
```