### PR TITLE
Add the `feat` keyword to version-update PRs to make sure they produce a new minor

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           author: GitHub <noreply@github.com>
           commit-message: Update Terraform versions
-          title: Update Terraform versions
+          title: "feat: Update Terraform versions" 
           body: |
             Automatically created pull-request to update Terraform versions.
 


### PR DESCRIPTION
Unless we manually add the `feat` keyword to the PRs produced by the `update-versions.py` script, there won't be a new minor version.