### PR TITLE
Update devenv template after recent integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
   template:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [build]
+    # needs: [build]
     strategy:
       matrix:
         template: [default, devenv, terranix]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
   template:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # needs: [build]
+    needs: [build]
     strategy:
       matrix:
         template: [default, devenv, terranix]

--- a/templates/devenv/flake.nix
+++ b/templates/devenv/flake.nix
@@ -6,12 +6,12 @@
     systems.url = "github:nix-systems/default";
   };
 
-  # nixConfig = {
-  #   extra-substituters = "https://nixpkgs-terraform.cachix.org";
-  #   extra-trusted-public-keys = "nixpkgs-terraform.cachix.org-1:8Sit092rIdAVENA3ZVeH9hzSiqI/jng6JiCrQ1Dmusw=";
-  # };
+  nixConfig = {
+    extra-substituters = "https://nixpkgs-terraform.cachix.org";
+    extra-trusted-public-keys = "nixpkgs-terraform.cachix.org-1:8Sit092rIdAVENA3ZVeH9hzSiqI/jng6JiCrQ1Dmusw=";
+  };
 
-  outputs = inputs@{ self, devenv, nixpkgs-terraform, nixpkgs, systems }:
+  outputs = inputs@{ self, devenv, nixpkgs, systems }:
     let
       forEachSystem = nixpkgs.lib.genAttrs (import systems);
     in
@@ -26,8 +26,6 @@
               inherit inputs pkgs;
               modules = [
                 ({ pkgs, config, ... }: {
-                  cachix.pull = [ "nixpkgs-terraform" "devenv" ];
-
                   languages.terraform.enable = true;
                   languages.terraform.version = "1.7.4";
                 })

--- a/templates/devenv/flake.nix
+++ b/templates/devenv/flake.nix
@@ -6,10 +6,10 @@
     systems.url = "github:nix-systems/default";
   };
 
-  nixConfig = {
-    extra-substituters = "https://nixpkgs-terraform.cachix.org";
-    extra-trusted-public-keys = "nixpkgs-terraform.cachix.org-1:8Sit092rIdAVENA3ZVeH9hzSiqI/jng6JiCrQ1Dmusw=";
-  };
+  # nixConfig = {
+  #   extra-substituters = "https://nixpkgs-terraform.cachix.org";
+  #   extra-trusted-public-keys = "nixpkgs-terraform.cachix.org-1:8Sit092rIdAVENA3ZVeH9hzSiqI/jng6JiCrQ1Dmusw=";
+  # };
 
   outputs = inputs@{ self, devenv, nixpkgs-terraform, nixpkgs, systems }:
     let
@@ -26,6 +26,8 @@
               inherit inputs pkgs;
               modules = [
                 ({ pkgs, config, ... }: {
+                  cachix.pull = [ "nixpkgs-terraform" "devenv" ];
+
                   languages.terraform.enable = true;
                   languages.terraform.version = "1.7.4";
                 })

--- a/templates/devenv/flake.nix
+++ b/templates/devenv/flake.nix
@@ -20,7 +20,6 @@
         (system:
           let
             pkgs = nixpkgs.legacyPackages.${system};
-            terraform = nixpkgs-terraform.packages.${system}."1.7.4";
           in
           {
             default = devenv.lib.mkShell {
@@ -28,7 +27,7 @@
               modules = [
                 ({ pkgs, config, ... }: {
                   languages.terraform.enable = true;
-                  languages.terraform.package = terraform;
+                  languages.terraform.version = "1.7.4";
                 })
               ];
             };


### PR DESCRIPTION
I'd like to use one of the new features of devenv, `cachix.pull`, but no luck so far. https://devenv.sh/binary-caching/