### PR TITLE
chore: Update versions daily

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,7 +3,7 @@ name: Update
 
 on:
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * *"
 
 concurrency:
   group: update


### PR DESCRIPTION
Run the `update-versions.py` daily instead of weekly to deliver new versions faster.

Related to https://github.com/stackbuilders/nixpkgs-terraform/issues/67.