### PR TITLE
feat: Add support for Terraform versions `1.8.2` and `1.8.3`

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,13 @@
 {
   "releases": {
+    "1.8.3": {
+      "hash": "sha256-4W1Cs3PAGn43eGDK15qSvN+gLdkkoFIwhejcJsCqcYA=",
+      "vendorHash": "sha256-2+ctm1lJjCHITWV7BqoqgBlXKjNT4lueAt4F3UtoL9Q="
+    },
+    "1.8.2": {
+      "hash": "sha256-c9RzdmaTXMOi4oP++asoysDpt/BSvBK/GmEDDGViSl0=",
+      "vendorHash": "sha256-2+ctm1lJjCHITWV7BqoqgBlXKjNT4lueAt4F3UtoL9Q="
+    },
     "1.8.1": {
       "hash": "sha256-q/r1KK0svdK/5Za4bqU6bGgTcWmG+YZFJUFRKqPAWSw=",
       "vendorHash": "sha256-xpgGceAA+kvwUp4T0m9rnbPoZ3uJHU2KIRsrcGr8dRo="
@@ -298,7 +306,7 @@
     }
   },
   "latest": {
-    "1.8": "1.8.1",
+    "1.8": "1.8.3",
     "1.7": "1.7.5",
     "1.6": "1.6.6",
     "1.5": "1.5.7",


### PR DESCRIPTION
This PR updates the versions.json file for version 1.8.2 and 1.8.3 of Terraform.