### PR TITLE
Bump go 1.22.7

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,6 +2,8 @@
 name: Update
 
 on:
+  pull_request:
+    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
@@ -17,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: bump-go-1.22.7
       - name: Install Nix
         uses: cachix/install-nix-action@V27
         with:
@@ -34,22 +36,22 @@ jobs:
         env:
           CLI_GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         working-directory: cli
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          author: GitHub <noreply@github.com>
-          commit-message: Update Terraform versions
-          title: "feat: Update Terraform versions"
-          body: |
-            Automatically created pull-request to update Terraform versions.
+      # - name: Create pull request
+      #   uses: peter-evans/create-pull-request@v6
+      #   with:
+      #     author: GitHub <noreply@github.com>
+      #     commit-message: Update Terraform versions
+      #     title: "feat: Update Terraform versions"
+      #     body: |
+      #       Automatically created pull-request to update Terraform versions.
 
-            This is the result of configuring a CLI_GITHUB_TOKEN in `.env` and running:
+      #       This is the result of configuring a CLI_GITHUB_TOKEN in `.env` and running:
 
-            ```
-            cli update-versions
-            ```
-          delete-branch: true
-          reviewers: |
-            oscar-izval
-            sestrella
-          token: ${{ secrets.BOT_TOKEN }}
+      #       ```
+      #       cli update-versions
+      #       ```
+      #     delete-branch: true
+      #     reviewers: |
+      #       oscar-izval
+      #       sestrella
+      #     token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,8 +2,6 @@
 name: Update
 
 on:
-  pull_request:
-    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
@@ -19,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: bump-go-1.22.7
+          ref: main
       - name: Install Nix
         uses: cachix/install-nix-action@V27
         with:
@@ -36,22 +34,22 @@ jobs:
         env:
           CLI_GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         working-directory: cli
-      # - name: Create pull request
-      #   uses: peter-evans/create-pull-request@v6
-      #   with:
-      #     author: GitHub <noreply@github.com>
-      #     commit-message: Update Terraform versions
-      #     title: "feat: Update Terraform versions"
-      #     body: |
-      #       Automatically created pull-request to update Terraform versions.
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          author: GitHub <noreply@github.com>
+          commit-message: Update Terraform versions
+          title: "feat: Update Terraform versions"
+          body: |
+            Automatically created pull-request to update Terraform versions.
 
-      #       This is the result of configuring a CLI_GITHUB_TOKEN in `.env` and running:
+            This is the result of configuring a CLI_GITHUB_TOKEN in `.env` and running:
 
-      #       ```
-      #       cli update-versions
-      #       ```
-      #     delete-branch: true
-      #     reviewers: |
-      #       oscar-izval
-      #       sestrella
-      #     token: ${{ secrets.BOT_TOKEN }}
+            ```
+            cli update-versions
+            ```
+          delete-branch: true
+          reviewers: |
+            oscar-izval
+            sestrella
+          token: ${{ secrets.BOT_TOKEN }}

--- a/cli/devenv.lock
+++ b/cli/devenv.lock
@@ -3,11 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1723102610,
+        "lastModified": 1726826452,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "6e318854efa95c5e67a1152547f838754e8f0306",
-        "treeHash": "6dadc5f8c13b1d27286128a4d910e3915cfc79d0",
+        "rev": "2bdf6461e88c7e93b94d72d8b11d5a61f167cbf5",
         "type": "github"
       },
       "original": {
@@ -24,7 +23,6 @@
         "owner": "edolstra",
         "repo": "flake-compat",
         "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "treeHash": "2addb7b71a20a25ea74feeaf5c2f6a6b30898ecb",
         "type": "github"
       },
       "original": {
@@ -45,7 +43,6 @@
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
         "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "treeHash": "ca14199cabdfe1a06a7b1654c76ed49100a689f9",
         "type": "github"
       },
       "original": {
@@ -60,7 +57,6 @@
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
         "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
-        "treeHash": "6d9f1f7ca0faf1bc2eeb397c78a49623260d3412",
         "type": "github"
       },
       "original": {
@@ -72,11 +68,10 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1722869614,
+        "lastModified": 1726838390,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "883180e6550c1723395a3a342f830bfc5c371f6b",
-        "treeHash": "e3ce01703c0d0324121e0d3ec6336275025b4ae6",
+        "rev": "944b2aea7f0a2d7c79f72468106bc5510cbf5101",
         "type": "github"
       },
       "original": {
@@ -96,11 +91,10 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723056346,
+        "lastModified": 1726745158,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3c977f1c9930f54066c085305b4b2291385e7a73",
-        "treeHash": "d6f89338ffb2ca32c20bc0f8d50009e1894ab804",
+        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
         "type": "github"
       },
       "original": {

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1711019207,
+        "lastModified": 1726826452,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "a7ba6766c0cc351b8656c63560c6b19c3788455f",
-        "treeHash": "5e0e1857cc23f45d07920937aa6589b97e4d0864",
+        "rev": "2bdf6461e88c7e93b94d72d8b11d5a61f167cbf5",
         "type": "github"
       },
       "original": {
@@ -24,30 +23,11 @@
         "owner": "edolstra",
         "repo": "flake-compat",
         "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "treeHash": "2addb7b71a20a25ea74feeaf5c2f6a6b30898ecb",
         "type": "github"
       },
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "treeHash": "bd263f021e345cb4a39d80c126ab650bebc3c10c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -63,7 +43,6 @@
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
         "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "treeHash": "ca14199cabdfe1a06a7b1654c76ed49100a689f9",
         "type": "github"
       },
       "original": {
@@ -74,11 +53,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710796454,
+        "lastModified": 1716977621,
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "06fb0f1c643aee3ae6838dda3b37ef0abc3c763b",
-        "treeHash": "9bb13f7f39e825a5d91bbe4139fbc129243b907d",
+        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
         "type": "github"
       },
       "original": {
@@ -90,16 +68,15 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1710951922,
+        "lastModified": 1726838390,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f091af045dff8347d66d186a62d42aceff159456",
-        "treeHash": "46b3620ce937feaa05c3d0b4e91bd003985947ee",
+        "rev": "944b2aea7f0a2d7c79f72468106bc5510cbf5101",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -107,7 +84,6 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -115,11 +91,10 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710923068,
+        "lastModified": 1726745158,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e611897ddfdde3ed3eaac4758635d7177ff78673",
-        "treeHash": "d7cff0ca3e7cdccd8ea9ef00f8534ef6b425cfc6",
+        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
         "type": "github"
       },
       "original": {
@@ -133,21 +108,6 @@
         "devenv": "devenv",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "treeHash": "cce81f2a0f0743b2eb61bc2eb6c7adbe2f2c6beb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -69,17 +69,17 @@
     },
     "nixpkgs-1_9": {
       "locked": {
-        "lastModified": 1727081528,
-        "narHash": "sha256-1gH6ewpAYTbrPIkNirmGYKDsiKFG0fOYXdlxLQ7K6dk=",
+        "lastModified": 1726871744,
+        "narHash": "sha256-V5LpfdHyQkUF7RfOaDPrZDP+oqz88lTJrMT1+stXNwo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0556c426ff33a3c26bafcf68291a1a9f09e4090b",
+        "rev": "a1d92660c6b3b7c26fb883500a80ea9d33321be2",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0556c426ff33a3c26bafcf68291a1a9f09e4090b",
+        "rev": "a1d92660c6b3b7c26fb883500a80ea9d33321be2",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -69,17 +69,17 @@
     },
     "nixpkgs-1_9": {
       "locked": {
-        "lastModified": 1721883900,
-        "narHash": "sha256-kTpK/TdIkQwtPZe1NjCF6nY0S21A7QiNjXju9rHdcrg=",
+        "lastModified": 1727081528,
+        "narHash": "sha256-1gH6ewpAYTbrPIkNirmGYKDsiKFG0fOYXdlxLQ7K6dk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f5fd8730397b9951d24de58f51a5e9cb327e2a85",
+        "rev": "0556c426ff33a3c26bafcf68291a1a9f09e4090b",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f5fd8730397b9951d24de58f51a5e9cb327e2a85",
+        "rev": "0556c426ff33a3c26bafcf68291a1a9f09e4090b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs-1_0.url = "github:nixos/nixpkgs/41de143fda10e33be0f47eab2bfe08a50f234267"; # nixos-23.05
     nixpkgs-1_6.url = "github:nixos/nixpkgs/d6b3ddd253c578a7ab98f8011e59990f21dc3932"; # nixos-24.05
-    nixpkgs-1_9.url = "github:nixos/nixpkgs/0556c426ff33a3c26bafcf68291a1a9f09e4090b"; # nixpkgs-unstable
+    nixpkgs-1_9.url = "github:nixos/nixpkgs/a1d92660c6b3b7c26fb883500a80ea9d33321be2"; # nixpkgs-unstable
     systems.url = "github:nix-systems/default";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs-1_0.url = "github:nixos/nixpkgs/41de143fda10e33be0f47eab2bfe08a50f234267"; # nixos-23.05
     nixpkgs-1_6.url = "github:nixos/nixpkgs/d6b3ddd253c578a7ab98f8011e59990f21dc3932"; # nixos-24.05
-    nixpkgs-1_9.url = "github:nixos/nixpkgs/f5fd8730397b9951d24de58f51a5e9cb327e2a85"; # nixpkgs-unstable
+    nixpkgs-1_9.url = "github:nixos/nixpkgs/0556c426ff33a3c26bafcf68291a1a9f09e4090b"; # nixpkgs-unstable
     systems.url = "github:nix-systems/default";
   };
 


### PR DESCRIPTION
Tested in [this run of the update workflow](https://github.com/stackbuilders/nixpkgs-terraform/actions/runs/10991787463/job/30514855334?pr=91) where the creation of the PR was disabled using this temp changes e7c42585ec64a6044f99882034ed4010be716cbc.

Changes:
- Bumped devenv for both the main project and the cli tool with `devenv update`.
- Changed the commit hash in the `nixpkgs-1_9` input to the latest one to get go 1.22.7 with `nix flake update nixpkgs-1_9`