### PR TITLE
feat: Add missing 1.10.X versions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -92,6 +92,18 @@
       "hash": "sha256-GvFBefp1RWqgB79Sv+2vYZyTjeLEYNsXFJrJxEUJAlY=",
       "vendorHash": "sha256-UmPnOfjR6kYI0TMH2J54LzDeDGJKMkAC0xZk6xstIuk="
     },
+    "1.10.1": {
+      "hash": "sha256-fOilZJbkPkGNcnKYBZtH81YE+XHsXsvxFAMt6YRcJCo=",
+      "vendorHash": "sha256-AajBuUwOhK0OniRRfCqR89+mA9LnQBkbG3Xge9c0qSQ="
+    },
+    "1.10.2": {
+      "hash": "sha256-dnoaiIOyZ6l1hGz/yjMwxrbKXioqWEpMSjiFA1zN3AY=",
+      "vendorHash": "sha256-AajBuUwOhK0OniRRfCqR89+mA9LnQBkbG3Xge9c0qSQ="
+    },
+    "1.10.3": {
+      "hash": "sha256-KY18YFTKWj366CPTh1MJ9DLamiFUVql3BhuMUzN7zf8=",
+      "vendorHash": "sha256-AajBuUwOhK0OniRRfCqR89+mA9LnQBkbG3Xge9c0qSQ="
+    },
     "1.2.0": {
       "hash": "sha256-5um+zS7MVL59SlxchjXdlhBGNdacbQgvg7BRAWnW5XU=",
       "vendorHash": "sha256-6x1cv+DKXH2yyMjIA6JY5EkTmWbwH4LBammXKtw2EZo="
@@ -356,7 +368,7 @@
   "latest": {
     "1.0": "1.0.11",
     "1.1": "1.1.9",
-    "1.10": "1.10.0",
+    "1.10": "1.10.3",
     "1.2": "1.2.9",
     "1.3": "1.3.10",
     "1.4": "1.4.7",


### PR DESCRIPTION
Since the automated workflow is broken, I generated these manually with [seppeljordan/nix-prefetch-github](https://github.com/seppeljordan/nix-prefetch-github) and `$ nix-prefetch-github hashicorp terraform --rev v1.10.X`. Then built the packages locally to get a correct vendorHash. This should be a temporary solution to make the new versions available for those using `>1.10.0`.

Closes https://github.com/stackbuilders/nixpkgs-terraform/issues/101.