### PR TITLE
feat: Manually add 1.10.4 and 1.10.5

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -104,6 +104,14 @@
       "hash": "sha256-KY18YFTKWj366CPTh1MJ9DLamiFUVql3BhuMUzN7zf8=",
       "vendorHash": "sha256-AajBuUwOhK0OniRRfCqR89+mA9LnQBkbG3Xge9c0qSQ="
     },
+    "1.10.4": {
+      "hash": "sha256-wJg/BfKWgDzv9HKOsNaq+l2jG37VbOtmBF+QEhNLQ1k=",
+      "vendorHash": "sha256-xyFguSjqUweZyoO97nkjLfJWS+eifNV7hpJUjh/6Z54="
+    },
+    "1.10.5": {
+      "hash": "sha256-6Y9r3VxL3DRvUaU6hLE+SdqjfIF+PAlXEYBPBc571QE=",
+      "vendorHash": "sha256-YFsPxDlD7SqHo0x2UQnsJ5jDTp2JXdhEgDvtIpWVQ9o="
+    },
     "1.2.0": {
       "hash": "sha256-5um+zS7MVL59SlxchjXdlhBGNdacbQgvg7BRAWnW5XU=",
       "vendorHash": "sha256-6x1cv+DKXH2yyMjIA6JY5EkTmWbwH4LBammXKtw2EZo="
@@ -368,7 +376,7 @@
   "latest": {
     "1.0": "1.0.11",
     "1.1": "1.1.9",
-    "1.10": "1.10.3",
+    "1.10": "1.10.5",
     "1.2": "1.2.9",
     "1.3": "1.3.10",
     "1.4": "1.4.7",

--- a/versions.json
+++ b/versions.json
@@ -106,11 +106,11 @@
     },
     "1.10.4": {
       "hash": "sha256-wJg/BfKWgDzv9HKOsNaq+l2jG37VbOtmBF+QEhNLQ1k=",
-      "vendorHash": "sha256-xyFguSjqUweZyoO97nkjLfJWS+eifNV7hpJUjh/6Z54="
+      "vendorHash": "sha256-YFsPxDlD7SqHo0x2UQnsJ5jDTp2JXdhEgDvtIpWVQ9o="
     },
     "1.10.5": {
       "hash": "sha256-6Y9r3VxL3DRvUaU6hLE+SdqjfIF+PAlXEYBPBc571QE=",
-      "vendorHash": "sha256-YFsPxDlD7SqHo0x2UQnsJ5jDTp2JXdhEgDvtIpWVQ9o="
+      "vendorHash": "sha256-xyFguSjqUweZyoO97nkjLfJWS+eifNV7hpJUjh/6Z54="
     },
     "1.2.0": {
       "hash": "sha256-5um+zS7MVL59SlxchjXdlhBGNdacbQgvg7BRAWnW5XU=",


### PR DESCRIPTION
Manually adding these versions while we work on a permanent solution for the update script.
I'm using nurl with `nurl --hash https://github.com/hashicorp/terraform v1.10.5` to get the hash and then `nix build .#"\"1.10.5"\" ` to get the vendorHash from the error message.