### PR TITLE
chore: Make `vendor-hash` less sensitive to `inputs` changes

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,10 +1,10 @@
 ---
 name: Update
 
-on: push
-  #   workflow_dispatch:
-  #   schedule:
-  #     - cron: "0 0 * * *"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 concurrency:
   group: update

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,10 +1,10 @@
 ---
 name: Update
 
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
+on: push
+  #   workflow_dispatch:
+  #   schedule:
+  #     - cron: "0 0 * * *"
 
 concurrency:
   group: update

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -33,17 +33,17 @@ jobs:
         id: update_versions
         run: |
           touch .env
-          title=$(devenv shell -- go run . update-versions --versions ../versions.json --vendor-hash ../vendor-hash.nix)
-          echo "title=$title" >> "$GITHUB_OUTPUT"
+          commit_message=$(devenv shell -- go run . update-versions --versions ../versions.json --vendor-hash ../vendor-hash.nix)
+          echo "commit_message=$commit_message" >> "$GITHUB_OUTPUT"
         env:
           CLI_GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       - name: Create pull request
-        if: ${{ steps.update_versions.outputs.title }}
+        if: ${{ steps.update_versions.outputs.commit_message }}
         uses: peter-evans/create-pull-request@v7
         with:
           author: GitHub <noreply@github.com>
-          commit-message: Update Terraform versions
-          title: ${{ steps.update_versions.outputs.title }}
+          commit-message: ${{ steps.update_versions.outputs.commit_message }}
+          title: ${{ steps.update_versions.outputs.commit_message }}
           body: |
             Automatically created pull-request to update Terraform versions.
 

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         system:
         let
           versions = builtins.fromJSON (builtins.readFile ./versions.json);
-          releases = self.lib.mkPackages {
+          releases = self.lib.__mkPackages {
             inherit inputs system;
             releases = versions.releases;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -9,39 +9,13 @@
   };
 
   outputs =
-    { self
+    inputs@{ self
     , nixpkgs
-    , nixpkgs-1_0
-    , nixpkgs-1_6
     , systems
     , ...
     }:
     let
       forAllSystems = nixpkgs.lib.genAttrs (import systems);
-
-      # Import nixpkgs for each supported system
-      pkgsFor = forAllSystems (
-        system:
-        import nixpkgs {
-          inherit system;
-          config.allowUnfree = true;
-        }
-      );
-
-      pkgs-1_0For = forAllSystems (
-        system:
-        import nixpkgs-1_0 {
-          inherit system;
-        }
-      );
-
-      pkgs-1_6For = forAllSystems (
-        system:
-        import nixpkgs-1_6 {
-          inherit system;
-          config.allowUnfree = true;
-        }
-      );
 
       # Create packages for each system
       packagesFor = forAllSystems (
@@ -49,11 +23,7 @@
         let
           versions = builtins.fromJSON (builtins.readFile ./versions.json);
           releases = self.lib.mkPackages {
-            allPkgs = {
-              "1.0" = pkgs-1_0For.${system};
-              "1.6" = pkgs-1_6For.${system};
-              "1.9" = pkgsFor.${system};
-            };
+            inherit inputs system;
             releases = versions.releases;
           };
           latestVersions = builtins.mapAttrs (_cycle: version: releases.${version}) versions.latest;

--- a/lib/build-for.nix
+++ b/lib/build-for.nix
@@ -1,0 +1,36 @@
+{ buildTerraform }:
+
+{ inputs
+, system
+, version
+, hash
+, vendorHash
+,
+}:
+
+let
+  pkgs-1_9 = import inputs.nixpkgs {
+    inherit system;
+    config.allowUnfree = true;
+  };
+  pkgs-1_6 = import inputs.nixpkgs-1_6 {
+    inherit system;
+    config.allowUnfree = true;
+  };
+  pkgs-1_0 = import inputs.nixpkgs-1_0 { inherit system; };
+in
+
+buildTerraform {
+  inherit
+    version
+    hash
+    vendorHash
+    ;
+  pkgs =
+    if builtins.compareVersions version "1.9.0" >= 0 then
+      pkgs-1_9
+    else if builtins.compareVersions version "1.6.0" >= 0 then
+      pkgs-1_6
+    else
+      pkgs-1_0;
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,4 +1,5 @@
 rec {
   buildTerraform = import ./build.nix;
-  mkPackages = import ./packages.nix { inherit buildTerraform; };
+  buildTerraformFor = import ./build-for.nix { inherit buildTerraform; };
+  mkPackages = import ./packages.nix { inherit buildTerraformFor; };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,5 @@
 rec {
   buildTerraform = import ./build.nix;
-  buildTerraformFor = import ./build-for.nix { inherit buildTerraform; };
-  mkPackages = import ./packages.nix { inherit buildTerraformFor; };
+  __buildTerraformFor = import ./build-for.nix { inherit buildTerraform; };
+  __mkPackages = import ./packages.nix { inherit __buildTerraformFor; };
 }

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -1,8 +1,7 @@
-{ buildTerraform
-,
-}:
+{ buildTerraformFor }:
 
-{ allPkgs
+{ inputs
+, system
 , releases
 ,
 }:
@@ -11,19 +10,14 @@ builtins.mapAttrs
   (
     version:
     { hash, vendorHash }:
-    buildTerraform {
+    buildTerraformFor {
       inherit
+        inputs
+        system
         version
         hash
         vendorHash
         ;
-      pkgs =
-        if builtins.compareVersions version "1.9.0" >= 0 then
-          allPkgs."1.9"
-        else if builtins.compareVersions version "1.6.0" >= 0 then
-          allPkgs."1.6"
-        else
-          allPkgs."1.0";
     }
   )
   releases

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -1,4 +1,4 @@
-{ buildTerraformFor }:
+{ __buildTerraformFor }:
 
 { inputs
 , system
@@ -10,7 +10,7 @@ builtins.mapAttrs
   (
     version:
     { hash, vendorHash }:
-    buildTerraformFor {
+    __buildTerraformFor {
       inherit
         inputs
         system

--- a/vendor-hash.nix
+++ b/vendor-hash.nix
@@ -4,7 +4,7 @@ let
   flake = builtins.getFlake (toString ./.);
   system = builtins.currentSystem;
 
-  terraform = flake.lib.buildTerraformFor {
+  terraform = flake.lib.__buildTerraformFor {
     inherit
       system
       version
@@ -14,4 +14,4 @@ let
     vendorHash = sha256;
   };
 in
-terraform.goModules or terraform.go-modules
+  terraform.goModules or terraform.go-modules

--- a/vendor-hash.nix
+++ b/vendor-hash.nix
@@ -1,24 +1,17 @@
-{ version, hash }: { sha256 }:
+{ version, hash }:
+{ sha256 }:
 let
   flake = builtins.getFlake (toString ./.);
   system = builtins.currentSystem;
 
-  pkgs-1_0 = flake.inputs.nixpkgs-1_0.legacyPackages.${system};
-  pkgs-1_6 = flake.inputs.nixpkgs-1_6.legacyPackages.${system};
-  pkgs = flake.inputs.nixpkgs.legacyPackages.${system};
-
-  finalPkgs =
-    if builtins.compareVersions version "1.9.0" >= 0 then
-      pkgs
-    else if builtins.compareVersions version "1.6.0" >= 0 then
-      pkgs-1_6
-    else
-      pkgs-1_0;
-
-  terraform = flake.lib.buildTerraform {
-    inherit version hash;
-    pkgs = finalPkgs;
+  terraform = flake.lib.buildTerraformFor {
+    inherit
+      system
+      version
+      hash
+      ;
+    inputs = flake.inputs;
     vendorHash = sha256;
   };
 in
-  terraform.goModules or terraform.go-modules
+terraform.goModules or terraform.go-modules


### PR DESCRIPTION
The following PR refactors `vendhor-hash.nix` to prevent breaking changes caused by adding or modifying flake inputs.