### PR TITLE
ci: Pins `devenv` version to avoid incompatibility issues between `devenv-1.5` and `nixpkgs-24.11`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,7 @@ jobs:
       # INFO: Latest `devenv` version is not compatible with `nixos-24.11`
       # channel
       - name: Install devenv
-        run: |
-          nix profile install --accept-flake-config github:cachix/devenv/v1.4.1
-          devenv version
+        run: nix profile install --accept-flake-config github:cachix/devenv/v1.4.1
       - name: Run tests
         run: devenv test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,7 @@ jobs:
       # INFO: Latest `devenv` version is not compatible with `nixos-24.11`
       # channel
       - name: Install devenv
-        run: |
-          nix profile install --accept-flake-config github:cachix/devenv/v1.4.1
-          devenv version
+        run: nix profile install --accept-flake-config github:cachix/devenv/v1.4.1
       - name: Run semantic-release
         run: devenv shell semantic-release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,9 @@ jobs:
       # INFO: Latest `devenv` version is not compatible with `nixos-24.11`
       # channel
       - name: Install devenv
-        run: nix profile install --accept-flake-config github:cachix/devenv/v1.4.1
+        run: |
+          nix profile install --accept-flake-config github:cachix/devenv/v1.4.1
+          devenv version
       - name: Run semantic-release
         run: devenv shell semantic-release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,10 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: devenv
+      # INFO: Latest `devenv` version is not compatible with `nixos-24.11`
+      # channel
       - name: Install devenv
-        run: nix-env -if https://install.devenv.sh/latest
+        run: nix profile install --accept-flake-config github:cachix/devenv/v1.4.1
       - name: Run semantic-release
         run: devenv shell semantic-release
         env:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -26,9 +26,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-24.11-small
       - name: Install devenv
-        run: |
-          nix profile install --accept-flake-config nixpkgs#devenv
-          devenv version
+        run: nix profile install --accept-flake-config github:cachix/devenv/v1.4.1
       - name: Update versions
         id: update_versions
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -25,6 +25,8 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-24.11-small
+      # INFO: Latest `devenv` version is not compatible with `nixos-24.11`
+      # channel
       - name: Install devenv
         run: nix profile install --accept-flake-config github:cachix/devenv/v1.4.1
       - name: Update versions


### PR DESCRIPTION
Pins the `devenv` version to `1.4` across all workflows to avoid an incompatibility issue between `devenv-1.5` and the `nixpkgs-24.11` channel:


<img width="963" alt="image" src="https://github.com/user-attachments/assets/ebed38f7-e367-4d8f-a563-fbb2eb9a5d6d" />


https://github.com/stackbuilders/nixpkgs-terraform/actions/runs/14575140576/job/40879567074