### PR TITLE
feat: Add Terraform 1.12 versions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -132,6 +132,14 @@
       "hash": "sha256-VGptJz+MbJ8nJRGUW9LzX6IDLYbjI5tK40ZhkZCGVf0=",
       "vendorHash": "sha256-pDtWGDKEnYq4wJYG+Rr5C1pWN/X92P+wvHrNm0Ldh+8="
     },
+    "1.12.0": {
+      "hash": "sha256-+EjsKl13kx3uJ50TrZIJLrvf4RBWDJsp1PD1dwtP6XA=",
+      "vendorHash": "sha256-zWNLIurNP5e/AWr84kQCb2+gZIn6EAsuvr0ZnfSq7Zw="
+    },
+    "1.12.1": {
+      "hash": "sha256-ikpSkcP4zt91Lf9gziytlZ4P27A0IP2qL+H2Lp9Cspg=",
+      "vendorHash": "sha256-zWNLIurNP5e/AWr84kQCb2+gZIn6EAsuvr0ZnfSq7Zw="
+    },
     "1.2.0": {
       "hash": "sha256-5um+zS7MVL59SlxchjXdlhBGNdacbQgvg7BRAWnW5XU=",
       "vendorHash": "sha256-6x1cv+DKXH2yyMjIA6JY5EkTmWbwH4LBammXKtw2EZo="
@@ -398,6 +406,7 @@
     "1.1": "1.1.9",
     "1.10": "1.10.5",
     "1.11": "1.11.4",
+    "1.12": "1.12.1",
     "1.2": "1.2.9",
     "1.3": "1.3.10",
     "1.4": "1.4.7",


### PR DESCRIPTION
Manually adding 1.12 versions while working on fixing the broken release and update workflows.

Release: https://github.com/stackbuilders/nixpkgs-terraform/actions/runs/15167632311
Update: https://github.com/stackbuilders/nixpkgs-terraform/actions/runs/15167877530

Fixes #124 