### PR TITLE
feat: Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,49 +2,49 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747728033,
-        "narHash": "sha256-NnXFQu7g4LnvPIPfJmBuZF7LFy/fey2g2+LCzjQhTUk=",
+        "lastModified": 1751596331,
+        "narHash": "sha256-7WSzIrw0nCl8iYroj7c//LLsf2zgNEIJNyUSvx4MPLI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2f9173bde1d3fbf1ad26ff6d52f952f9e9da52ea",
+        "rev": "472908faa934435cf781ae8fac77291af3d137d3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "2f9173bde1d3fbf1ad26ff6d52f952f9e9da52ea",
         "type": "github"
       }
     },
     "nixpkgs-1_0": {
       "locked": {
-        "lastModified": 1699291058,
-        "narHash": "sha256-5ggduoaAMPHUy4riL+OrlAZE14Kh7JWX4oLEs22ZqfU=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "41de143fda10e33be0f47eab2bfe08a50f234267",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-23.05-small",
         "repo": "nixpkgs",
-        "rev": "41de143fda10e33be0f47eab2bfe08a50f234267",
         "type": "github"
       }
     },
     "nixpkgs-1_6": {
       "locked": {
-        "lastModified": 1712757991,
-        "narHash": "sha256-kR7C7Fqt3JP40h0mzmSZeWI5pk1iwqj4CSeGjnUbVHc=",
+        "lastModified": 1735651292,
+        "narHash": "sha256-YLbzcBtYo1/FEzFsB3AnM16qFc6fWPMIoOuSoDwvg9g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6b3ddd253c578a7ab98f8011e59990f21dc3932",
+        "rev": "0da3c44a9460a26d2025ec3ed2ec60a895eb1114",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-24.05-small",
         "repo": "nixpkgs",
-        "rev": "d6b3ddd253c578a7ab98f8011e59990f21dc3932",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,12 @@
   description = "A collection of Terraform versions that are automatically updated";
 
   inputs = {
-    nixpkgs-1_0.url = "github:nixos/nixpkgs/41de143fda10e33be0f47eab2bfe08a50f234267"; # nixos-23.05
-    nixpkgs-1_6.url = "github:nixos/nixpkgs/d6b3ddd253c578a7ab98f8011e59990f21dc3932"; # nixos-24.05
-    nixpkgs.url = "github:nixos/nixpkgs/2f9173bde1d3fbf1ad26ff6d52f952f9e9da52ea"; # nixpkgs-unstable
+    # INFO: Channel used for building versions from 1.0 up to 1.5
+    nixpkgs-1_0.url = "github:nixos/nixpkgs/nixos-23.05-small";
+    # INFO: Channel used for building versions from 1.6 up to 1.8
+    nixpkgs-1_6.url = "github:nixos/nixpkgs/nixos-24.05-small";
+    # INFO: Channel used for building versions from 1.9 onwards
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
   };
 


### PR DESCRIPTION
This pull request updates the `flake.nix` file to use more descriptive and streamlined URLs for Nixpkgs channels, providing clarity on their purpose and scope.

Key changes in `flake.nix`:

* Updated the `nixpkgs-1_0.url` to use the `nixos-23.05-small` channel with a comment explaining its scope for building versions from 1.0 to 1.5.
* Updated the `nixpkgs-1_6.url` to use the `nixos-24.05-small` channel with a comment explaining its scope for building versions from 1.6 to 1.8.
* Updated the `nixpkgs.url` to use the `nixpkgs-unstable` channel with a comment explaining its scope for building versions from 1.9 onwards.