### PR TITLE
ci: Add missing flag for template dirs to the update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Update versions
         id: update
         run: |
-          commit_message=$(devenv shell -- go run . update --versions ../versions.json --vendor-hash ../vendor-hash.nix)
+          commit_message=$(devenv shell -- go run . update --versions ../versions.json --vendor-hash ../vendor-hash.nix --templates-dir ../templates)
           echo "commit_message=$commit_message" >> "$GITHUB_OUTPUT"
         env:
           CLI_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -57,7 +57,7 @@ jobs:
 
             ```
             cd cli
-            go run . update --versions ../versions.json --vendor-hash ../vendor-hash.nix
+            go run . update --versions ../versions.json --vendor-hash ../vendor-hash.nix --templates-dir ../templates
             ```
           delete-branch: true
           reviewers: |


### PR DESCRIPTION
After the recent addition of the `--templates-dir` flag to the update command, we are missing a small change in the CI workflow that makes use of this command. This will fix it and also enable the new flag to take effect.