### PR TITLE
ci: Send notifications when the `update` workflow fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   check:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -31,8 +32,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13      # x86_64-darwin
-          - macos-latest  # aarch64-darwin
+          - macos-13 # x86_64-darwin
+          - macos-latest # aarch64-darwin
           - ubuntu-latest # x86_64-linux
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ concurrency:
 
 jobs:
   check:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -32,8 +31,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13 # x86_64-darwin
-          - macos-latest # aarch64-darwin
+          - macos-13      # x86_64-darwin
+          - macos-latest  # aarch64-darwin
           - ubuntu-latest # x86_64-linux
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,9 +2,11 @@
 name: Update
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
+  push
+
+  # workflow_dispatch:
+  # schedule:
+  #   - cron: "0 0 * * *"
 
 concurrency:
   group: update
@@ -39,9 +41,10 @@ jobs:
         run: nix profile install --accept-flake-config github:cachix/devenv/latest
       - name: Update versions
         id: update
-        run: |
-          commit_message=$(devenv shell -- go run . update --versions ../versions.json --vendor-hash ../vendor-hash.nix --templates-dir ../templates)
-          echo "commit_message=$commit_message" >> "$GITHUB_OUTPUT"
+        run: exit 1
+        # run: |
+        #   commit_message=$(devenv shell -- go run . update --versions ../versions.json --vendor-hash ../vendor-hash.nix --templates-dir ../templates)
+        #   echo "commit_message=$commit_message" >> "$GITHUB_OUTPUT"
         env:
           CLI_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Create pull request
@@ -64,3 +67,13 @@ jobs:
             oscar-izval
             sestrella
           token: ${{ steps.app-token.outputs.token }}
+
+  notify:
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    needs: [update]
+    steps:
+      - uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -77,3 +77,7 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
+          payload: |
+            {
+              "text": ":x: *${{ github.workflow }}* failed on *${{ github.ref_name }}* (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|open run>)"
+            }

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,6 +23,7 @@ jobs:
       run:
         working-directory: cli
     steps:
+      - run: exit 1
       - name: Create GH App token
         uses: actions/create-github-app-token@v2
         id: app-token
@@ -41,10 +42,9 @@ jobs:
         run: nix profile install --accept-flake-config github:cachix/devenv/latest
       - name: Update versions
         id: update
-        run: exit 1
-        # run: |
-        #   commit_message=$(devenv shell -- go run . update --versions ../versions.json --vendor-hash ../vendor-hash.nix --templates-dir ../templates)
-        #   echo "commit_message=$commit_message" >> "$GITHUB_OUTPUT"
+        run: |
+          commit_message=$(devenv shell -- go run . update --versions ../versions.json --vendor-hash ../vendor-hash.nix --templates-dir ../templates)
+          echo "commit_message=$commit_message" >> "$GITHUB_OUTPUT"
         env:
           CLI_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Create pull request

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -79,5 +79,5 @@ jobs:
           webhook-type: webhook-trigger
           payload: |
             {
-              "text": ":x: *${{ github.workflow }}* failed on *${{ github.ref_name }}* (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|open run>)"
+              "text": "*nixpkgs-terraform*: :elmofire: *${{ github.workflow }}* failed on *${{ github.ref_name }}* (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|open run>)"
             }

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -66,7 +66,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
   notify:
-    if: ${{ failure() }}
+    if: failure()
     runs-on: ubuntu-latest
     needs: [update]
     steps:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,11 +2,9 @@
 name: Update
 
 on:
-  push
-
-  # workflow_dispatch:
-  # schedule:
-  #   - cron: "0 0 * * *"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 concurrency:
   group: update
@@ -23,7 +21,6 @@ jobs:
       run:
         working-directory: cli
     steps:
-      - run: exit 1
       - name: Create GH App token
         uses: actions/create-github-app-token@v2
         id: app-token
@@ -79,5 +76,5 @@ jobs:
           webhook-type: webhook-trigger
           payload: |
             {
-              "text": "*nixpkgs-terraform*: :elmofire: *${{ github.workflow }}* failed on *${{ github.ref_name }}* (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|open run>)"
+              "text": "*nixpkgs-terraform*: :elmofire: *${{ github.workflow }}* workflow failed on *${{ github.ref_name }}* (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|open run>)"
             }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751596331,
-        "narHash": "sha256-7WSzIrw0nCl8iYroj7c//LLsf2zgNEIJNyUSvx4MPLI=",
+        "lastModified": 1756381814,
+        "narHash": "sha256-tzo7YvAsGlzo4WiIHT0ooR59VHu+aKRQdHk7sIyoia4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "472908faa934435cf781ae8fac77291af3d137d3",
+        "rev": "aca2499b79170038df0dbaec8bf2f689b506ad32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This pull request adds a notification step to the GitHub Actions workflow. Now, if the `update` job fails, a Slack message will be sent to alert the team.

Workflow improvements:

* Added a `notify` job to `.github/workflows/update.yml` that triggers on failure of the `update` job and sends a Slack message using the `slackapi/slack-github-action`.

Fixes: #125 