### PR TITLE
ci(cli): Make easier to call the `update` command locally without a GH token

### DIFF
--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -79,7 +79,7 @@ var updateCmd = &cobra.Command{
 
 		token := os.Getenv("CLI_GITHUB_TOKEN")
 		if token == "" {
-			return fmt.Errorf("Environment variable CLI_GITHUB_TOKEN is missing")
+			log.Println("Warning: CLI_GITHUB_TOKEN is not set. Requests to GitHub API may be rate limited.")
 		}
 
 		versionsPath, err := filepath.Abs(versionsPath)
@@ -139,7 +139,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		if len(messages) > 0 {
-			fmt.Printf("feat: %s\n", strings.Join(messages, "/"))
+			fmt.Printf("feat: %s\n", strings.Join(messages, " / "))
 		}
 		return nil
 	},
@@ -300,7 +300,10 @@ func readVersions(versionsPath string) (*Versions, error) {
 }
 
 func getRepoReleases(token string) ([]github.RepositoryRelease, error) {
-	client := github.NewClient(nil).WithAuthToken(token)
+	client := github.NewClient(nil)
+	if token != "" {
+		client = client.WithAuthToken(token)
+	}
 	opt := &github.ListOptions{Page: 1}
 
 	var allReleases []github.RepositoryRelease


### PR DESCRIPTION
This pull request makes improvements to the handling of the `CLI_GITHUB_TOKEN` environment variable in the `cli/cmd/update.go` file. The changes ensure that the application does not fail if the token is missing, and instead logs a warning and gracefully handles unauthenticated requests to the GitHub API.

Error handling and authentication improvements:

* Changed the behavior when `CLI_GITHUB_TOKEN` is missing: instead of returning an error, the code now logs a warning message and continues, which allows the CLI to run in environments where the token is not set, albeit with possible rate limiting.
* Updated the GitHub client initialization in `getRepoReleases` to only use the authentication token if it is present, allowing unauthenticated requests when the token is missing.