### PR TITLE
ci: Change build job to only push binaries at the end

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,16 +43,9 @@ jobs:
         with:
           name: nixpkgs-terraform
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          skipPush: true
+          skipPush: ${{ github.ref_name != 'main' }}
       - name: Build packages
-        run: |
-          if grep -q authToken ~/.config/cachix/cachix.dhall; then
-            echo "Cachix token is present"
-            cachix watch-exec nixpkgs-terraform nix -- flake check
-          else
-            echo "Cachix token is not present"
-            nix flake check
-          fi
+        run: nix flake check
 
   template:
     runs-on: ubuntu-latest

--- a/devenv.nix
+++ b/devenv.nix
@@ -5,5 +5,5 @@
     pkgs.semantic-release
   ];
 
-  pre-commit.hooks.nixpkgs-fmt.enable = true;
+  git-hooks.hooks.nixpkgs-fmt.enable = true;
 }


### PR DESCRIPTION
This pull request makes minor improvements to the build workflow and development environment configuration, focusing on streamlining CI logic and updating the pre-commit hook configuration.

**Build workflow improvements:**

* Updated the `skipPush` parameter in `.github/workflows/build.yml` to only skip pushing when the branch is not `main`, improving caching behavior in CI.
* Simplified the package build step in `.github/workflows/build.yml` by removing conditional logic for checking the presence of the Cachix token; now always runs `nix flake check`.

**Development environment configuration:**

* Changed the pre-commit hook configuration in `devenv.nix` to use `git-hooks` instead of `pre-commit` for enabling `nixpkgs-fmt`, aligning with updated tooling.