### PR TITLE
ci: Run action linters as part of the `check` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+        with:
+          name: devenv
       - name: Install devenv
-        run: nix profile add --accept-flake-config github:cachix/devenv/v1.8
+        run: nix profile add github:cachix/devenv/latest
       - name: Run tests
         run: devenv test
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -5,5 +5,9 @@
     pkgs.semantic-release
   ];
 
-  git-hooks.hooks.nixpkgs-fmt.enable = true;
+  git-hooks.hooks = {
+    action-validator.enable = true;
+    actionlint.enable = true;
+    nixpkgs-fmt.enable = true;
+  };
 }


### PR DESCRIPTION
This PR adds some safety nets for caching issues to GH actions workflow files early in the development process.