### PR TITLE
fix: Fix publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   check:
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ concurrency:
 
 jobs:
   check:
-    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
-on: push
-  # release:
-  #   types: [released]
+on:
+  release:
+    types: [released]
 
 concurrency:
   group: publish
@@ -14,7 +14,6 @@ permissions:
 
 jobs:
   flakehub:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -29,26 +28,10 @@ jobs:
           tag: ${{ github.ref_name }}
           visibility: public
 
-  # INFO: The following fork updates the Nix version used by the action to fix
-  # the "lastModified" issue. https://flakehub.com/docs/faq#err-last-modified
   flakestry:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version:
-          - v5.21.0
-          - v5.20.0
-          - v5.19.0
-          - v5.18.0
-          - v5.17.0
-          - v5.16.0
-          - v5.15.0
-          - v5.14.0
-      fail-fast: true
     steps:
       - name: Publish flake
         uses: flakestry/flakestry-publish@main
         with:
-          version: ${{ matrix.version }}
-          ref: ${{ matrix.version }}
-          # version: ${{ github.ref_name }}
+          version: ${{ github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,22 @@ jobs:
   # the "lastModified" issue. https://flakehub.com/docs/faq#err-last-modified
   flakestry:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - v5.21.0
+          - v5.20.0
+          - v5.19.0
+          - v5.18.0
+          - v5.17.0
+          - v5.16.0
+          - v5.15.0
+          - v5.14.0
+      fail-fast: true
     steps:
       - name: Publish flake
         uses: flakestry/flakestry-publish@main
         with:
-          version: v5.22.0
-          ref: v5.22.0
+          version: ${{ matrix.version }}
+          ref: ${{ matrix.version }}
           # version: ${{ github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
-on:
-  release:
-    types: [released]
+on: push
+  # release:
+  #   types: [released]
 
 concurrency:
   group: publish
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   flakehub:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -34,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish flake
-        uses: stackbuilders/flakestry-publish@update_install_nix_action
+        uses: flakestry/flakestry-publish@main
         with:
-          version: ${{ github.ref_name }}
+          version: v5.22.0
+          # version: ${{ github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,4 +38,5 @@ jobs:
         uses: flakestry/flakestry-publish@main
         with:
           version: v5.22.0
+          ref: v5.22.0
           # version: ${{ github.ref_name }}


### PR DESCRIPTION
This PR resolves the broken flakestry job. Additionally, the missing versions have been released to [Flakestry](https://flakestry.dev/flake/github/stackbuilders/nixpkgs-terraform/5.22.0); more information on this commit https://github.com/stackbuilders/nixpkgs-terraform/pull/181/changes/619ab20fca0bd65acc7297cffff41de6705bc8b4.

