### PR TITLE
ci: normalize devenv versions on all pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           name: devenv
       - name: Install devenv
-        run: nix profile add nixpkgs#devenv
+        run: nix profile add --accept-flake-config nixpkgs#devenv
       - name: Run tests
         run: devenv test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           name: devenv
       - name: Install devenv
-        run: nix profile add --accept-flake-config github:cachix/devenv/v1.8
+        run: nix profile add --accept-flake-config nixpkgs#devenv
       - name: Run semantic-release
         run: devenv shell semantic-release
         env:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
       - name: Install devenv
-        run: nix profile add --accept-flake-config github:cachix/devenv/latest
+        run: nix profile add --accept-flake-config nixpkgs#devenv
       - name: Compile cli
         run: devenv shell -- go build .
         working-directory: cli

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1778814374,
-        "narHash": "sha256-gZIaq9to5brzEsnlHE2D0FRN4ixZJEBd2ZV/3WNlt4Q=",
+        "lastModified": 1780630679,
+        "narHash": "sha256-hhQyVAYmNKziZ0T+T4Gsk0PYmnz4vdzOzpkJAmDASKM=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "e44d88a683bf945c72445babd85f1d2e4e933409",
+        "rev": "90ed6227ab389dd4e874a69a724f25dba312b754",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Description
Previously we encountered some issues in devenv that were solved based on the usage and commands being called. Those relate to `devenv` being on a state where it was migrating to the v2 version. Currently those issues are solved and normalizing the calls and versions into all our stack improves maintainability and reproducibility.